### PR TITLE
Add content-type header to metrics server response.

### DIFF
--- a/beacon_node/http_metrics/src/lib.rs
+++ b/beacon_node/http_metrics/src/lib.rs
@@ -116,7 +116,13 @@ pub fn serve<T: BeaconChainTypes>(
         .and_then(|ctx: Arc<Context<T>>| async move {
             Ok::<_, warp::Rejection>(
                 metrics::gather_prometheus_metrics(&ctx)
-                    .map(|body| Response::builder().status(200).body(body).unwrap())
+                    .map(|body| {
+                        Response::builder()
+                            .status(200)
+                            .header("Content-Type", "text/plain")
+                            .body(body)
+                            .unwrap()
+                    })
                     .unwrap_or_else(|e| {
                         Response::builder()
                             .status(500)

--- a/beacon_node/http_metrics/tests/tests.rs
+++ b/beacon_node/http_metrics/tests/tests.rs
@@ -1,6 +1,7 @@
 use beacon_chain::test_utils::EphemeralHarnessType;
 use environment::null_logger;
 use http_metrics::Config;
+use reqwest::header::HeaderValue;
 use reqwest::StatusCode;
 use std::net::{IpAddr, Ipv4Addr};
 use std::sync::Arc;
@@ -45,7 +46,13 @@ async fn returns_200_ok() {
             listening_socket.port()
         );
 
-        assert_eq!(reqwest::get(&url).await.unwrap().status(), StatusCode::OK);
+        let response = reqwest::get(&url).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get("Content-Type").unwrap(),
+            &HeaderValue::from_str("text/plain").unwrap()
+        );
     }
     .await
 }


### PR DESCRIPTION
This fixes issues with certain metrics scrapers, which might error if the content-type is not correctly set.

## Issue Addressed

Fixes https://github.com/sigp/lighthouse/issues/3437

## Proposed Changes

Simply return set header: `Content-Type: text/plain` on metrics server response.

## Additional Info

This is needed also to enable influx-db metric scraping which work very nicely with Geth.

